### PR TITLE
Make rspec more verbose by enabling the --format documentation option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation


### PR DESCRIPTION
- Add a .rspec file with the `--format documentation` option enabled